### PR TITLE
Prevent name from being overridden

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -110,9 +110,6 @@ function privateGo(options) {
     return;
   }
 
-  // Send a name in as well
-  if (!name) name = email;
-
   del(traits, 'email');
   del(traits, 'name');
 
@@ -126,10 +123,13 @@ function privateGo(options) {
 
   ramenSettings.organization_id = integration.options.organization_id;
   ramenSettings.user = {
-    name: name,
     id: id,
     email: email
   };
+
+  if (name) {
+    ramenSettings.user.name = name;
+  }
 
   if (created) {
     ramenSettings.user.created_at = Math.round(created / 1000);
@@ -224,7 +224,7 @@ function privateGo(options) {
   window.ramenSettings = extend(ramenSettings, window.ramenSettings || {});
 
   // Ramen.go() will figure things out if called multiple times
-  window.Ramen.go();
+  window.Ramen.go(ramenSettings, options);
 
   if (options.track) {
     window.Ramen.Api.track_named(options.track.event());

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -140,7 +140,7 @@ describe('Ramen', function() {
         analytics.identify('id', { email: email });
         analytics.assert(window.ramenSettings.organization_id === '6389149');
         analytics.assert(window.ramenSettings.user.id === 'id');
-        analytics.assert(window.ramenSettings.user.name === email);
+        analytics.assert(typeof window.ramenSettings.user.name === 'undefined');
         analytics.assert(window.ramenSettings.user.email === email);
         analytics.called(window.Ramen.go);
       });


### PR DESCRIPTION
One of our customers is calling `identify` multiples times: sometimes with a name & sometimes without. In the without case, we were overriding the names to `==` the email address. This PR fixes that.
