### PR TITLE
Remove `email` trait requirement & support anonymous users

### DIFF
--- a/component.json
+++ b/component.json
@@ -6,13 +6,11 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
+    "segmentio/alias": "0.2.1",
     "timoxley/next-tick": "0.0.2",
     "segmentio/convert-dates": "0.1.0",
-    "avetisk/defaults": "0.0.1",
-    "segmentio/extend": "1.0.0",
     "segmentio/obj-case": "0.2.1",
-    "segmentio/analytics.js-integration": "^1.1.0",
-    "ianstormtaylor/is": "0.1.0"
+    "segmentio/analytics.js-integration": "^1.1.0"
   },
   "development": {
     "segmentio/analytics.js-core": "^2.12.0",

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,10 +6,9 @@
 
 var integration = require('analytics.js-integration');
 var convertDates = require('convert-dates');
-var defaults = require('defaults');
-var is = require('is');
 var del = require('obj-case').del;
-var extend = require('extend');
+var alias = require('alias');
+
 
 /**
  * Expose `Ramen` integration.
@@ -17,7 +16,7 @@ var extend = require('extend');
 
 var Ramen = module.exports = integration('Ramen')
   .global('Ramen')
-  .global('ramenSettings')
+  .global('_ramen')
   .option('organization_id', '')
   .tag('<script src="//cdn.ramen.is/assets/ramen.js">');
 
@@ -28,14 +27,12 @@ var Ramen = module.exports = integration('Ramen')
  */
 
 Ramen.prototype.initialize = function() {
-  var self = this;
-
-  window.ramenSettings = {
-    _partner: 'segment.com',
-    disable_location_watch: true
-  };
-
-  this.load(self.ready);
+  window._ramen = window._ramen || [];
+  /* eslint-disable */
+  (function(){var a,b,c; a = function(f){return function(){window._ramen.push([f].concat(Array.prototype.slice.call(arguments,0))); }; }; b = ["boot","ready","identify","group","track","page","reset","ask"]; for (c = 0; c < b.length; c++) {window._ramen[b[c]] = a(b[c]); } })();
+  /* eslint-enable */
+  window._ramen.boot(this.options.organization_id, this.options);
+  this.load(this.ready);
 };
 
 /**
@@ -46,7 +43,57 @@ Ramen.prototype.initialize = function() {
  */
 
 Ramen.prototype.loaded = function() {
-  return is.object(window.Ramen);
+  return !!(window._ramen && window._ramen.push !== Array.prototype.push);
+};
+
+/**
+ * Group.
+ *
+ * @api public
+ * @param {Group} group
+ */
+
+Ramen.prototype.group = function(group) {
+  if (!this.identified) {
+    window._ramen.identify();
+    this.identified = true;
+  }
+
+  var props = group.traits({ createdAt: 'created', created: 'created_at' });
+  if (group.groupId()) props.id = group.groupId();
+
+  window._ramen.group(props);
+};
+
+/**
+ * Page.
+ *
+ * @api public
+ */
+
+Ramen.prototype.page = function() {
+  if (!this.identified) {
+    window._ramen.identify();
+    this.identified = true;
+  }
+
+  window._ramen.page();
+};
+
+/**
+ * Track.
+ *
+ * @api public
+ * @param {Track} track
+ */
+
+Ramen.prototype.track = function(track) {
+  if (!this.identified) {
+    window._ramen.identify();
+    this.identified = true;
+  }
+
+  window._ramen.track(track.event());
 };
 
 /**
@@ -57,176 +104,58 @@ Ramen.prototype.loaded = function() {
  */
 
 Ramen.prototype.identify = function(identify) {
-  privateGo({ integration: this, identify: identify });
-};
+  // Ramen requires that `identify`'d users have an `id`.
+  // For anonymous visitors, simply do not call `analytics.identify`
+  // and the rest of the integration will handle it.
+  if (!identify.userId()) return;
 
-Ramen.prototype.group = function(group) {
-  privateGo({ integration: this, group: group });
-};
-
-Ramen.prototype.page = function(page) {
-  privateGo({ integration: this, page: page });
-};
-
-Ramen.prototype.track = function(track) {
-  privateGo({ integration: this, track: track });
-};
-
-function privateGo(options) {
-  var integration = options.integration;
-  var ramenSettings = {};
-  var property;
-  var identify;
+  var user;
   var traits;
   var opts;
-  var user_opts;
-  var created;
-  var name;
-  var id;
-  var email;
-  var group;
 
-  if (options.identify) {
-    identify = options.identify;
-    traits = identify.traits();
-    opts = identify.options(integration.name);
-    user_opts = opts.user;
-    created = identify.created();
-    name = identify.name();
-    id = identify.uid();
-    email = identify.email();
-    group = integration.analytics.group();
-  } else {
-    traits = {};
-    group = {};
-    opts = {};
+  traits = identify.traits();
+  opts = identify.options(this.name);
+
+  // Setup the basic `user` attributes: id, email, created_at, and name
+  // `null` values are OK. Ramen will ignore them.
+
+  user = { id: identify.userId() };
+
+  if (traits.email) {
+    user.email = traits.email;
   }
 
-  email = email || integration.analytics.user().traits().email;
-  id = id || integration.analytics.user().id();
-
-  // We need email addresses
-  if (!email) {
-    return;
+  if (identify.created()) {
+    user.created_at = identify.created();
   }
 
+  if (identify.name()) {
+    user.name = identify.name();
+  }
+
+  if (traits.company && traits.company.id) {
+    user.company = alias(traits.company, { createdAt: 'created', created: 'created_at' });
+  }
+
+  // Clear out Ramen-specific values from traits, set traits to equal
+  // `user.traits`
   del(traits, 'email');
   del(traits, 'name');
+  del(traits, 'id');
+  del(traits, 'created');
+  del(traits, 'createdAt');
+  del(traits, 'company');
+  user.traits = traits;
 
-  if (traits.company !== null && !is.object(traits.company)) {
-    delete traits.company;
-  }
+  // Convert all timestamps to epoch seconds
+  user = convertDates(user, function(date) { return Math.floor(date / 1000); });
 
-  if (traits.company && typeof group.traits === 'function') {
-    defaults(traits.company, group.traits());
-  }
+  user.traits = alias(user.traits, { createdAt: 'created' });
+  user.traits = alias(user.traits, { created: 'created_at' });
 
-  ramenSettings.organization_id = integration.options.organization_id;
-  ramenSettings.user = {
-    id: id,
-    email: email
-  };
+  // Rename `auth_hash_timestamp` to `timestamp` for secure mode
+  opts = alias(opts, { auth_hash_timestamp: 'timestamp' });
 
-  if (name) {
-    ramenSettings.user.name = name;
-  }
-
-  if (created) {
-    ramenSettings.user.created_at = Math.round(created / 1000);
-    del(traits, 'created_at');
-    del(traits, 'created');
-    del(traits, 'createdAt');
-  }
-
-  // Iterate through company traits and load them on ramenSettings.company
-  if (traits.company) {
-    var tc = traits.company;
-    ramenSettings.company = {
-      name: tc.name,
-      url: tc.url,
-      id: tc.id,
-      value: tc.value,
-      labels: tc.labels,
-      traits: {}
-    };
-
-    del(tc, 'name');
-    del(tc, 'url');
-    del(tc, 'id');
-    del(tc, 'value');
-    del(tc, 'labels');
-
-    tc = convertDates(tc, function(date) { return Math.floor(date / 1000); });
-    for (property in tc) {
-      if (tc.hasOwnProperty(property)) {
-        ramenSettings.company.traits[property] = tc[property];
-      }
-    }
-
-    del(traits, 'company');
-  }
-
-  // Iterate through user options and load them on ramenSettings.user
-  if (user_opts) {
-    for (property in user_opts) {
-      if (user_opts.hasOwnProperty(property)) {
-        ramenSettings.user[property] = user_opts[property];
-      }
-    }
-
-    // Delete user from opts so we don't override in the next loop
-    del(opts, 'user');
-  }
-
-  traits = convertDates(traits, function(date) { return Math.floor(date / 1000); });
-
-  for (property in traits) {
-    if (traits.hasOwnProperty(property)) {
-      ramenSettings.user.traits = ramenSettings.user.traits || {};
-      ramenSettings.user.traits[property] = traits[property];
-    }
-  }
-
-  // Iterate through options and load them on ramenSettings
-  for (property in opts) {
-    if (opts.hasOwnProperty(property)) {
-      ramenSettings[property] = opts[property];
-    }
-  }
-
-  if (ramenSettings.auth_hash_timestamp) {
-    ramenSettings.timestamp = ramenSettings.auth_hash_timestamp;
-    del(ramenSettings, 'auth_hash_timestamp');
-  }
-
-  if (options.group) {
-    group = options.group;
-    var props = group.properties();
-    props.created_at = group.created();
-    if (props.created_at) {
-      props.created_at = Math.round(props.created_at / 1000);
-    }
-    del(props, 'created');
-    del(props, 'createdAt');
-    id = group.groupId();
-    if (id) props.id = id;
-
-    // Iterate through properties and send them along to Ramen through ramenSettings
-    ramenSettings.company = {};
-    for (property in props) {
-      if (props.hasOwnProperty(property)) {
-        ramenSettings.company[property] = props[property];
-      }
-    }
-  }
-
-  // Expose ramenSettings so Ramen.go() can see it
-  window.ramenSettings = extend(ramenSettings, window.ramenSettings || {});
-
-  // Ramen.go() will figure things out if called multiple times
-  window.Ramen.go(ramenSettings, options);
-
-  if (options.track) {
-    window.Ramen.Api.track_named(options.track.event());
-  }
-}
+  window._ramen.identify(user, opts);
+  this.identified = true;
+};


### PR DESCRIPTION
Hi there,

We recently made two changes to Ramen that require changes to our integration library. First, we no longer require users to have an `email` attribute, we need to remove the check for that.

We also now support calling `identify()` with no traits (aka [Anonymous Users](https://ramen.is/blog/release-notes-anonymous-users-conditional-follow-ups-new-ramenjs-api-more/)), but we wanted to reinforce that our API would not be called until the user was `identify`'d, hence the addition of the `this.identified` check.
